### PR TITLE
Parameterized API_PORT for master API port

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -10,6 +10,7 @@ export VERSION=${VERSION:="v3.7.1"}
 export SCRIPT_REPO=${SCRIPT_REPO:="https://raw.githubusercontent.com/gshipley/installcentos/master"}
 
 export IP="$(ip route get 8.8.8.8 | awk '{print $NF; exit}')"
+export API_PORT=${API_PORT:="8443"}
 
 echo "******"
 echo "* Your domain is $DOMAIN "
@@ -92,13 +93,13 @@ oc adm policy add-cluster-role-to-user cluster-admin ${USERNAME}
 systemctl restart origin-master-api
 
 echo "******"
-echo "* Your conosle is https://console.$DOMAIN:8443"
+echo "* Your conosle is https://console.$DOMAIN:$API_PORT"
 echo "* Your username is $USERNAME "
 echo "* Your password is $PASSWORD "
 echo "*"
 echo "* Login using:"
 echo "*"
-echo "$ oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:8443/"
+echo "$ oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:$API_PORT/"
 echo "******"
 
-oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:8443/
+oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:$API_PORT/

--- a/inventory.ini
+++ b/inventory.ini
@@ -44,5 +44,5 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 openshift_public_hostname=console.${DOMAIN}
 openshift_master_default_subdomain=apps.${DOMAIN}
-openshift_master_api_port=443
-openshift_master_console_port=443
+openshift_master_api_port=${API_PORT}
+openshift_master_console_port=${API_PORT}

--- a/inventory.ini
+++ b/inventory.ini
@@ -32,7 +32,6 @@ openshift_pkg_version=${VERSION}
 openshift_image_tag=${VERSION}
 openshift_service_catalog_image_version=${VERSION}
 template_service_broker_image_version=${VERSION}
-template_service_broker_selector={"region":"infra"}
 openshift_metrics_image_version=${VERSION}
 #openshift_logging_image_version=${VERSION}
 

--- a/inventory.ini
+++ b/inventory.ini
@@ -32,6 +32,7 @@ openshift_pkg_version=${VERSION}
 openshift_image_tag=${VERSION}
 openshift_service_catalog_image_version=${VERSION}
 template_service_broker_image_version=${VERSION}
+template_service_broker_selector={"region":"infra"}
 openshift_metrics_image_version=${VERSION}
 #openshift_logging_image_version=${VERSION}
 

--- a/inventory.ini
+++ b/inventory.ini
@@ -44,3 +44,5 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 
 openshift_public_hostname=console.${DOMAIN}
 openshift_master_default_subdomain=apps.${DOMAIN}
+openshift_master_api_port=443
+openshift_master_console_port=443


### PR DESCRIPTION
This change allows the user to select whether to use the default 8443 or to declare a different port (like 443) for his deployment. It's useful when the default clashes in the local machine.

I also applied the fix from https://bugzilla.redhat.com/show_bug.cgi?id=1538616.