### PR TITLE
Ajusting docker version to install

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -20,7 +20,7 @@ echo "******"
 
 yum install -y epel-release
 
-yum install -y git wget zile nano net-tools docker \
+yum install -y git wget zile nano net-tools docker-1.12.6 \
 python-cryptography pyOpenSSL.x86_64 python2-pip \
 openssl-devel python-devel httpd-tools NetworkManager python-passlib \
 java-1.8.0-openjdk-headless "@Development Tools"


### PR DESCRIPTION
Openshift 3.7.1 only supports docker 1.12.6. Today this script download 1.13 version.