### PR TITLE
Fix for logging oauth-proxy image version

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -36,6 +36,7 @@ template_service_broker_image_version=${VERSION}
 template_service_broker_selector={"region":"infra"}
 openshift_metrics_image_version="v3.9"
 openshift_logging_image_version="v3.9"
+openshift_logging_elasticsearch_proxy_image_version="v1.0.0"
 
 osm_use_cockpit=true
 


### PR DESCRIPTION
By default openshift-ansible logging playbooks defined value of openshift_logging_elasticsearch_proxy_image_version from openshift_logging_image_version if set.
But docker.io/openshift/oauth-proxy doesn't have v3.9 tag.

So define openshift_logging_elasticsearch_proxy_image_version as v1.0.0 which is default value if openshift_logging_image_version if not set (see [this](https://github.com/openshift/openshift-ansible/blob/release-3.9/roles/openshift_logging_elasticsearch/vars/default_images.yml#L8), [this](https://github.com/openshift/openshift-ansible/blob/release-3.9/roles/openshift_logging_elasticsearch/tasks/main.yaml#L37) and [this](https://github.com/openshift/openshift-ansible/blob/release-3.9/roles/openshift_logging_elasticsearch/tasks/main.yaml#L472))