### PR TITLE
Add an option to specify cluster users

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -43,7 +43,7 @@ openshift_metrics_install_metrics=${METRICS}
 openshift_logging_install_logging=${LOGGING}
 
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
-
+openshift_master_htpasswd_users={'admin': '$apr1$qrRCPRbu$JcZRzCFVV.Bk5TSEskUM8/'}
 openshift_public_hostname=console.${DOMAIN}
 openshift_master_default_subdomain=apps.${DOMAIN}
 openshift_master_api_port=${API_PORT}


### PR DESCRIPTION
Add an option to specify cluster users which will be added automatically during cluster installation

openshift_master_htpasswd_users={'admin': '$apr1$qrRCPRbu$JcZRzCFVV.Bk5TSEskUM8/'}