### PR TITLE
Fixes #91, fixes #93, fixes #95, fixes #99: No package matching 'origin-node-3.11*: add a repo in inventory.ini

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -45,3 +45,6 @@ openshift_public_hostname=console.${DOMAIN}
 openshift_master_default_subdomain=apps.${DOMAIN}
 openshift_master_api_port=${API_PORT}
 openshift_master_console_port=${API_PORT}
+
+openshift_additional_repos=[{'id': 'centos-okd-ci', 'name': 'centos-okd-ci', 'baseurl' :'https://rpms.svc.ci.openshift.org/openshift-origin-v3.11', 'gpgcheck' :'0', 'enabled' :'1'}]
+


### PR DESCRIPTION
This fix was created based on this comment: https://github.com/openshift/openshift-ansible/issues/9875#issuecomment-429967431.

In the CentOS epel-release repo, the origin-node-3.11* rpm is missing. However, we can add the https://rpms.svc.ci.openshift.org repo in the inventory.ini file.