### PR TITLE
Ansible 2.7.0 is not compatible with openshift-ansible

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -81,7 +81,8 @@ if [ $? -eq 1 ]; then
 fi
 
 # install the packages for Ansible
-yum -y --enablerepo=epel install ansible pyOpenSSL
+yum -y --enablerepo=epel install pyOpenSSL
+sudo rpm -iUvh https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.6.5-1.el7.ans.noarch.rpm
 
 [ ! -d openshift-ansible ] && git clone https://github.com/openshift/openshift-ansible.git
 


### PR DESCRIPTION
The current script calls for yum install ansible, this however causes the installer to fail as the Fedora epel repo now only hosts ansible 2.7.0 which is not supported. 
Initially I attempted to indicate a different version of ansible 2.6.5, but that one is no longer hosted on the epel repo see link: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/a/ansible-doc-2.6.5-1.el7.noarch.rpm
The best way i found to fix this, at least for now is to get the rpm directly from ansible. 
sudo rpm -iUvh https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.6.5-1.el7.ans.noarch.rpm