### PR TITLE
[#140] Removed deprecated variable openshift_node_kubelet_args

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -24,7 +24,7 @@ containerized=True
 os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 openshift_disable_check=disk_availability,docker_storage,memory_availability,docker_image_availability
 
-openshift_node_kubelet_args={'pods-per-core': ['10']}
+#openshift_node_kubelet_args={'pods-per-core': ['10']}
 
 deployment_type=origin
 openshift_deployment_type=origin

--- a/inventory.ini
+++ b/inventory.ini
@@ -24,8 +24,6 @@ containerized=True
 os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 openshift_disable_check=disk_availability,docker_storage,memory_availability,docker_image_availability
 
-#openshift_node_kubelet_args={'pods-per-core': ['10']}
-
 deployment_type=origin
 openshift_deployment_type=origin
 


### PR DESCRIPTION
This is a fix as per work around https://github.com/gshipley/installcentos/issues/140#issuecomment-458051875

openshift_node_kubelet_args inventory variable was deprecated in 3.10 and removed in 3.11.
This causes the ansible install to fail.
Also confirmed in Openshift-Ansible : https://github.com/openshift/openshift-ansible/issues/11069#issuecomment-457214101

This means the configuration this is no longer as intended, so this is not a real fix, HOWEVER, the default value for pods per core has been 10 since 3.3.
https://docs.openshift.com/container-platform/3.11/admin_guide/manage_nodes.html#admin-guide-max-pods-per-node
If needed the value can be adjusted in /etc/origin/node/node-config.yaml