### PR TITLE
adding Bare mtetal hetzner install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://github.com/mpeterson/rdo-openshift-tools
 
 # Install on Hetzner-bare-metal Server
 
-In oder to have a more openshift-a-like environment there is now a manual of how to run this on a bare-metal-box
+In oder to have a more openshift-a-like environment there is now a manual of how to run this on a bare-metal-box.
 Please check: [all-in-one-hetzner-bare-metal](all-in-one-hetzner-bare-metal.md)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Install ODK in a virtual box
+
 Install RedHat OKD 3.11 on your own server.  For a local only install, it is suggested that you use CDK or MiniShift instead of this repo.  This install method is targeted for a single node cluster that has a long life.
 
 This repository is a set of scripts that will allow you easily install the latest version (3.11) of OKD in a single node fashion.  What that means is that all of the services required for OKD to function (master, node, etcd, etc.) will all be installed on a single host.  The script supports a custom hostname which you can provide using the interactive mode.
@@ -14,6 +16,11 @@ https://github.com/mpeterson/rdo-openshift-tools
 > **Warning about Let's Encrypt setup available on this project:**
 > Let's Encrypt only works if the IP is using publicly accessible IP and custom certificates."
 > This feature doesn't work with OpenShift CLI for now.
+
+# Install on Hetzner-bare-metal Server
+
+In oder to have a more openshift-a-like environment there is now a manual of how to run this on a bare-metal-box
+Please check: [all-in-one-hetzner-bare-metal](all-in-one-hetzner-bare-metal.md)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Install ODK in a virtual box
+# Install ODK in a CentOS virtual box
 
 Install RedHat OKD 3.11 on your own server.  For a local only install, it is suggested that you use CDK or MiniShift instead of this repo.  This install method is targeted for a single node cluster that has a long life.
 

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -62,7 +62,9 @@ Skip 2.
 and clone with:
 
 ```
-export GIT_BASE_DIR=https://github.com/wrenkredhat/installcentos
+#Use your Git-Fork or use:
+export GIT_BASE_DIR=https://github.com/gshipley/installcentos
+
 git clone $GIT_BASE_DIR
 ```
 Then Export the follwing variables; these will take control over the
@@ -83,4 +85,4 @@ cd installcentos
 
 While the installation is running you might want to configure the FireWall:
 
-<link>
+https://github.com/RedHat-EMEA-SSA-Team/hetzner-ocp#firewall

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -78,7 +78,6 @@ Then Export the follwing variables; these will take control over the
 process os installation where relevant:
 
 ```
-export SCRIPT_REPO=$GIT_BASE_DIR/blob/master
 export METRICS="False"
 export LOGGING="False"
 ```
@@ -90,7 +89,7 @@ cd installcentos
 ./install-openshift.sh
 ```
 
-# Secure System with Firewallh
+# Secure System with Firewall
 
 While the installation is running you might want to configure the FireWall:
 

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -1,18 +1,26 @@
-This decribes a way of how to run the installation on a bare metal hetzner Box.
 
-This is done without installing the logging/metrics System, because there is absolutly no value added when
-The purpose is to have a real openshift smell like development-sandbox and is siutable for presestions as well.
+# ODK on Bare Metal Deploymnet
+
+This  manual describes a way of how to run the installation on a bare metal hetzner box.
+
+It is meant to complement [Hetzner OCP](https://github.com/RedHat-EMEA-SSA-Team/hetzner-ocp), where a cluster like setup is not needed or appropriate.
+
+This is done without installing the logging/metrics System, because there is no value added when someone needs an environment for app-developement/customising apps or executing a showcase.
+The purpose is to have a real openshift smell like development-sandbox but not a fully blown cluster.
+
+The procedure can be executed in approximatly 3-4h, where attention is needed for 1-2h approx.
+
+
+#Install Base OS
 
 There is a preparation to be achieved.
-
-
 
 This is taken from:
 
 https://github.com/RedHat-EMEA-SSA-Team/hetzner-ocp#install-instructions
 
 The simplest way of partitioning is:
-´´´
+```
 DRIVE1 /dev/sda
 DRIVE2 /dev/sdb
 SWRAID 1
@@ -29,14 +37,14 @@ LV vg0   home   /home   ext4      40G
 
 
 IMAGE /root/.oldroot/nfs/install/../images/CentOS-76-64-minimal.tar.gz
-´´´
+```
 
-for a box 2*2GB. If the imgage is not avalilible just check for the next version of CentOS.
+for a box 2*2GB. If the imgge is not avalilible just check for the next version of CentOS.
 
 
-After installting the the image the first to to is enable SELinux, as it comes disabled:
+After installing the the image the first to to is enable SELinux, as it comes disabled:
 
-´´´
+```
 vi /etc/selinux/config
 SELINUX=enforcing
 reboot/login
@@ -47,10 +55,9 @@ getenfore
 yum -y install screen git
 
 
-´´´
+```
 
-then follow:
-
+# Install ODK
 
 
 Please read the section upfront but shlighly change some commands
@@ -82,6 +89,8 @@ export LOGGING="False"
 cd installcentos
 ./install-openshift.sh
 ```
+
+# Secure System with Firewallh
 
 While the installation is running you might want to configure the FireWall:
 

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -64,20 +64,24 @@ Please read the section upfront but shlighly change some commands
 
 https://github.com/gshipley/installcentos
 
-Skip 2.
+Skip strep 2.
 
 and clone with:
 
 ```
 #Use your Git-Fork or use:
-export GIT_BASE_DIR=https://github.com/gshipley/installcentos
-
-git clone $GIT_BASE_DIR
+export GIT_USER=gshipley
+git clone https://github.com/${GIT_USER}/installcentos
 ```
 Then Export the follwing variables; these will take control over the
 process os installation where relevant:
 
+
+
 ```
+### Optional: export SCRIPT_REPO=browse to your **RAW** fork of rep:
+### export SCRIPT_REPO=https://raw.githubusercontent.com/${GIT_USER}/installcentos/master 
+
 export METRICS="False"
 export LOGGING="False"
 ```

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -13,12 +13,28 @@ https://github.com/RedHat-EMEA-SSA-Team/hetzner-ocp#install-instructions
 
 The simplest way of partitioning is:
 ´´´
+DRIVE1 /dev/sda
+DRIVE2 /dev/sdb
+SWRAID 1
+SWRAIDLEVEL 1
+BOOTLOADER grub
+HOSTNAME CentOS-76-64-minimal
+PART /boot ext3     512M
+PART lvm   vg0       all
 
+LV vg0   root   /       ext4     200G
+LV vg0   swap   swap    swap       5G
+LV vg0   tmp    /tmp    ext4      10G
+LV vg0   home   /home   ext4      40G
+
+
+IMAGE /root/.oldroot/nfs/install/../images/CentOS-76-64-minimal.tar.gz
 ´´´
 
+for a box 2*2GB. If the imgage is not avalilible just check for the next version of CentOS.
 
 
-Fst tinh to to is enable SELinux, as it comes disabled:
+After installting the the image the first to to is enable SELinux, as it comes disabled:
 
 ´´´
 vi /etc/selinux/config
@@ -29,18 +45,33 @@ getenfore
 
 
 yum -y install screen git
+
+
 ´´´
 
 then follow:
 
-But skip 1.
 
-1. Create a VM as explained in https://www.youtube.com/watch?v=ZkFIozGY0IA (this video) by Grant Shipley
 
-2. Clone this repo
+Please read the section upfront but shlighly change some commands
+
+https://github.com/gshipley/installcentos
+
+Skip 2.
+
+and clone with:
 
 ```
-git clone https://github.com/gshipley/installcentos.git
+export GIT_BASE_DIR=https://github.com/wrenkredhat/installcentos
+git clone $GIT_BASE_DIR
+```
+Then Export the follwing variables; these will take control over the
+process os installation where relevant:
+
+```
+export SCRIPT_REPO=$GIT_BASE_DIR/blob/master
+export METRICS="False"
+export LOGGING="False"
 ```
 
 3. Execute the installation script
@@ -50,55 +81,6 @@ cd installcentos
 ./install-openshift.sh
 ```
 
-## Automation
-1. Define mandatory variables for the installation process
+While the installation is running you might want to configure the FireWall:
 
-```
-# Domain name to access the cluster
-$ export DOMAIN=<public ip address>.nip.io
-
-# User created after installation
-$ export USERNAME=<current user name>
-
-# Password for the user
-$ export PASSWORD=password
-```
-
-2. Define optional variables for the installation process
-
-```
-# Instead of using loopback, setup DeviceMapper on this disk.
-# !! All data on the disk will be wiped out !!
-$ export DISK="/dev/sda"
-```
-
-3. Run the automagic installation script as root with the environment variable in place:
-
-```
-curl https://raw.githubusercontent.com/gshipley/installcentos/master/install-openshift.sh | INTERACTIVE=false /bin/bash
-```
-
-## Development
-
-For development it's possible to switch the script repo
-
-```
-# Change location of source repository
-$ export SCRIPT_REPO="https://raw.githubusercontent.com/gshipley/installcentos/master"
-$ curl $SCRIPT_REPO/install-openshift.sh | /bin/bash
-```
-
-## Testing
-
-The script is tested using the tooling in the `validate` directory.
-
-To use the tooling, it's required to create file `validate/env.sh` with the DigitalOcean API key
-
-```
-export DIGITALOCEAN_TOKEN=""
-```
-
-and then run `start.sh` to start the provisioning. Once the ssh is connected to the server, the
-script will atatch to the `tmux` session running Ansible installer.
-
-To destroy the infrastructure, run the `stop.sh` script.
+<link>

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -1,5 +1,5 @@
 
-# ODK on Bare Metal Deploymnet
+# ODK bare Metal Deploymnet
 
 This  manual describes a way of how to run the installation on a bare metal hetzner box.
 

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -1,0 +1,104 @@
+This decribes a way of how to run the installation on a bare metal hetzner Box.
+
+This is done without installing the logging/metrics System, because there is absolutly no value added when
+The purpose is to have a real openshift smell like development-sandbox and is siutable for presestions as well.
+
+There is a preparation to be achieved.
+
+
+
+This is taken from:
+
+https://github.com/RedHat-EMEA-SSA-Team/hetzner-ocp#install-instructions
+
+The simplest way of partitioning is:
+´´´
+
+´´´
+
+
+
+Fst tinh to to is enable SELinux, as it comes disabled:
+
+´´´
+vi /etc/selinux/config
+SELINUX=enforcing
+reboot/login
+getenfore
+-> Enfocing
+
+
+yum -y install screen git
+´´´
+
+then follow:
+
+But skip 1.
+
+1. Create a VM as explained in https://www.youtube.com/watch?v=ZkFIozGY0IA (this video) by Grant Shipley
+
+2. Clone this repo
+
+```
+git clone https://github.com/gshipley/installcentos.git
+```
+
+3. Execute the installation script
+
+```
+cd installcentos
+./install-openshift.sh
+```
+
+## Automation
+1. Define mandatory variables for the installation process
+
+```
+# Domain name to access the cluster
+$ export DOMAIN=<public ip address>.nip.io
+
+# User created after installation
+$ export USERNAME=<current user name>
+
+# Password for the user
+$ export PASSWORD=password
+```
+
+2. Define optional variables for the installation process
+
+```
+# Instead of using loopback, setup DeviceMapper on this disk.
+# !! All data on the disk will be wiped out !!
+$ export DISK="/dev/sda"
+```
+
+3. Run the automagic installation script as root with the environment variable in place:
+
+```
+curl https://raw.githubusercontent.com/gshipley/installcentos/master/install-openshift.sh | INTERACTIVE=false /bin/bash
+```
+
+## Development
+
+For development it's possible to switch the script repo
+
+```
+# Change location of source repository
+$ export SCRIPT_REPO="https://raw.githubusercontent.com/gshipley/installcentos/master"
+$ curl $SCRIPT_REPO/install-openshift.sh | /bin/bash
+```
+
+## Testing
+
+The script is tested using the tooling in the `validate` directory.
+
+To use the tooling, it's required to create file `validate/env.sh` with the DigitalOcean API key
+
+```
+export DIGITALOCEAN_TOKEN=""
+```
+
+and then run `start.sh` to start the provisioning. Once the ssh is connected to the server, the
+script will atatch to the `tmux` session running Ansible installer.
+
+To destroy the infrastructure, run the `stop.sh` script.

--- a/all-in-one-hetzner-bare-metal.md
+++ b/all-in-one-hetzner-bare-metal.md
@@ -1,5 +1,5 @@
 
-# ODK bare Metal Deploymnet
+# ODK bare metal deploymnet
 
 This  manual describes a way of how to run the installation on a bare metal hetzner box.
 

--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -147,8 +147,8 @@ if [ ! -f ~/.ssh/id_rsa ]; then
 	ssh -o StrictHostKeyChecking=no root@$IP "pwd" < /dev/null
 fi
 
-export METRICS="True"
-export LOGGING="True"
+export METRICS=${METRICS:="True"}
+export LOGGING=${LOGGING:="True"}
 
 memory=$(cat /proc/meminfo | grep MemTotal | sed "s/MemTotal:[ ]*\([0-9]*\) kB/\1/")
 

--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -160,7 +160,8 @@ if [ "$memory" -lt "16777216" ]; then
 	export LOGGING="False"
 fi
 
-curl -o inventory.download $SCRIPT_REPO/inventory.ini
+#curl -o inventory.download $SCRIPT_REPO/inventory.ini
+cp inventory.ini inventory.download
 envsubst < inventory.download > inventory.ini
 
 # add proxy in inventory.ini if proxy variables are set

--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -160,8 +160,7 @@ if [ "$memory" -lt "16777216" ]; then
 	export LOGGING="False"
 fi
 
-#curl -o inventory.download $SCRIPT_REPO/inventory.ini
-cp inventory.ini inventory.download
+curl -o inventory.download $SCRIPT_REPO/inventory.ini
 envsubst < inventory.download > inventory.ini
 
 # add proxy in inventory.ini if proxy variables are set

--- a/inventory.ini
+++ b/inventory.ini
@@ -3,6 +3,8 @@ masters
 nodes
 etcd
 
+##TEST##
+
 [masters]
 ${IP} openshift_ip=${IP} openshift_schedulable=true 
 


### PR DESCRIPTION
Hello,

i did expand this Rep and  install.sh order to make in run not on a virtual machine, but directly on bare metal. - Cent OD Hetzner-Server.
I really think it makes sense to add this to the main-Repo.
maybe we can consolidate later on the Team-Hetzner-OCP, the three platforms:
Lib-Virt-based virtualized multi-node-server.
openstack-based deployment you where referencing and
all in one in bare-metal or VM-Based fashion.
What do you think ?

Kind regards

Wolfgang