### PR TITLE
added console-internal to hosts append step 

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -116,7 +116,7 @@ yum -y --enablerepo=epel install ansible.rpm
 cat <<EOD > /etc/hosts
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4 
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
-${IP}		$(hostname) console console.${DOMAIN}  
+${IP}		$(hostname) console console.${DOMAIN} console-internal.${DOMAIN} 
 EOD
 
 if [ -z $DISK ]; then 


### PR DESCRIPTION
during the installation process, the task that waits for the control plane to come up would fail all it's 60 attempts with an error saying dial tcp console-internal.[domain] no such host 

the soluton in my case was to add it as another hosts file entry as part of Grant's wrapper script

