### PR TITLE
fixing registry & dns resolution conflict in 3.9

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -257,3 +257,15 @@ echo "$ oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:$API_PORT
 echo "******"
 
 oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:$API_PORT/
+
+echo "* Fixing the DNS resolution issue"
+#Comment all entries in /etc/resolv.conf and inlcude `nameserver 192.168.1.8`. Make /etc/resolv.conf readonly to avoid overwriting by origin
+sed -i s/^/"#"/g resolv.conf
+echo "nameserver $IP" >> resolv.conf
+chattr +i /etc/resolv.conf
+
+#Add  registry pod IP to /etc/hosts for registry dns resolution 
+registryIP=$(oc get service/docker-registry -n default -o json | grep clusterIP | awk '{split($0,array,":")} END{print array[2]}')
+echo "$registryIP docker-registry.default.svc" | tr -d "\"","," >> resolv.conf
+
+


### PR DESCRIPTION
Either origin registry is not resolved or all external domains like github.com are not resolved by openshift resources like pods.
 /etc/resolv.conf is updated automatically by origin with some search entries, which makes pods doesnt able to resolve the external domain names like github,google etc. which often causes the deployment failures. 

To fix that we need to add nameserver IPaddress to /etc/resolv.conf and comment search entries and make it readonly. so Origin cannot update it during restart. This makes Origin not able to resolve docker-registry.default.svc and deployments will fail. So we need to add docker-registry.default.svc and its cluster IP to /etc/hosts.

after the edits, 

/etc/resolv.conf should look like
[root@master ~]# cat /etc/resolv.conf
# nameserver updated by /etc/NetworkManager/dispatcher.d/99-origin-dns.sh
# Generated by NetworkManager
#search cluster.local 192.168.1.8.nip.io
nameserver 192.168.1.8

/etc/hosts should look like

[root@master ~]# cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
192.168.1.8 test01.osdemo.com master.192.168.1.8.nip.io console console.master.192.168.1.8.nip.io
172.30.202.99 docker-registry.default.svc


This way, pods can resolve both docker registry and external domains and deployments work after install